### PR TITLE
Reading History View

### DIFF
--- a/AtomReader.xcodeproj/project.pbxproj
+++ b/AtomReader.xcodeproj/project.pbxproj
@@ -75,6 +75,7 @@
 		2DAA20672AFEFB900098222E /* Feed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DAA20662AFEFB900098222E /* Feed.swift */; };
 		2DAA20692AFEFD1C0098222E /* Store.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DAA20682AFEFD1C0098222E /* Store.swift */; };
 		2DAA206B2AFEFF110098222E /* StoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DAA206A2AFEFF110098222E /* StoreTests.swift */; };
+		2DEA8A232B0D06C9004E0E54 /* ReadingHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DEA8A222B0D06C9004E0E54 /* ReadingHistoryView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -159,6 +160,7 @@
 		2DAA20662AFEFB900098222E /* Feed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feed.swift; sourceTree = "<group>"; };
 		2DAA20682AFEFD1C0098222E /* Store.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Store.swift; sourceTree = "<group>"; };
 		2DAA206A2AFEFF110098222E /* StoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreTests.swift; sourceTree = "<group>"; };
+		2DEA8A222B0D06C9004E0E54 /* ReadingHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingHistoryView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -217,6 +219,7 @@
 				2D4D681D2B01374A00C8EFAA /* ArticleFilterView.swift */,
 				2D4D68A82B095D8000C8EFAA /* SettingsView.swift */,
 				2D4D68AC2B09671600C8EFAA /* AppIconPickerView.swift */,
+				2DEA8A222B0D06C9004E0E54 /* ReadingHistoryView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -559,6 +562,7 @@
 				2D4D68752B0591B700C8EFAA /* DefaultPersistenceManagerIO.swift in Sources */,
 				2D4D68412B01670D00C8EFAA /* RemoveFeedAction.swift in Sources */,
 				2D4D686D2B0585A600C8EFAA /* ReadArticle.swift in Sources */,
+				2DEA8A232B0D06C9004E0E54 /* ReadingHistoryView.swift in Sources */,
 				2DAA20672AFEFB900098222E /* Feed.swift in Sources */,
 				2D4D683B2B014CAE00C8EFAA /* AddFeedAction.swift in Sources */,
 				2D4D68A92B095D8000C8EFAA /* SettingsView.swift in Sources */,

--- a/AtomReader/Business/ReadingHistoryStore.swift
+++ b/AtomReader/Business/ReadingHistoryStore.swift
@@ -61,6 +61,14 @@ extension ReadingHistoryStore {
 }
 
 extension ReadingHistoryStore {
+    func clear() {
+        readArticles.removeAll()
+        
+        persistenceManager?.save(readArticles)
+    }
+}
+
+extension ReadingHistoryStore {
     func isArticleRead(_ article: Article) -> Bool {
         readArticles.contains(where: { $0.article == article })
     }

--- a/AtomReader/Business/ReadingHistoryStore.swift
+++ b/AtomReader/Business/ReadingHistoryStore.swift
@@ -34,12 +34,26 @@ final class ReadingHistoryStore {
 
 extension ReadingHistoryStore {
     func mark(article: Article, read: Bool) {
-        if let index = readArticles.firstIndex(where: { $0.id == article.id }) {
-            readArticles.remove(at: index)
-        }
+        mark(articles: [article], read: read)
+    }
+    
+    func mark(articles: some Sequence<Article>, read: Bool) {
+        let offsets = readArticles
+            .enumerated()
+            .filter({ item in
+                articles.contains(where: { articleToBeMarked in
+                    articleToBeMarked.id == item.element.id
+                })
+            })
+            .map(\.offset)
+        
+        readArticles.remove(atOffsets: IndexSet(offsets))
         
         if read {
-            readArticles.append(ReadArticle(article: article, readAt: Date()))
+            let readAt = Date()
+            readArticles.append(
+                contentsOf: articles.map({ ReadArticle(article: $0, readAt: readAt) })
+            )
         }
         
         persistenceManager?.save(readArticles)

--- a/AtomReader/Misc/ArticleFilter.swift
+++ b/AtomReader/Misc/ArticleFilter.swift
@@ -10,6 +10,7 @@ import Foundation
 enum ArticleFilter: Equatable, Hashable {
     case none
     case feed(Feed.ID)
+    case history
 }
 
 extension ArticleFilter: Identifiable {

--- a/AtomReader/View/Actions/OpenArticleAction.swift
+++ b/AtomReader/View/Actions/OpenArticleAction.swift
@@ -12,6 +12,7 @@ struct OpenArticleAction: AppAction, Hashable {
     let article: Article
     var shouldOpenArticleInApp: Bool?
     var shouldOpenArticlesInSheet: Bool?
+    var shouldSkipHistoryTracking: Bool = false
 }
 
 fileprivate struct OpenArticleActionHandler: ViewModifier {
@@ -69,7 +70,9 @@ fileprivate struct OpenArticleActionHandler: ViewModifier {
             openUrl(action.article.articleUrl)
         }
         
-        readingHistory.mark(article: action.article, read: true)
+        if !action.shouldSkipHistoryTracking {
+            readingHistory.mark(article: action.article, read: true)
+        }
     }
 }
 

--- a/AtomReader/View/ArticleFilterView.swift
+++ b/AtomReader/View/ArticleFilterView.swift
@@ -12,14 +12,21 @@ struct ArticleFilterView: View {
     
     var body: some View {
         List(selection: $filter) {
-            Text("All")
-                .tag(ArticleFilter.none)
+            Section {
+                Text("All")
+                    .tag(ArticleFilter.none)
+            }
             
             Section {
                 ForEachFeed { feed in
                     FeedRowView(feed: feed)
                         .tag(ArticleFilter.feed(feed.id))
                 }
+            }
+            
+            Section {
+                Text("Reading History")
+                    .tag(ArticleFilter.history)
             }
         }
     }

--- a/AtomReader/View/ArticleListView.swift
+++ b/AtomReader/View/ArticleListView.swift
@@ -43,8 +43,8 @@ struct ArticleListView: View {
         .refreshable {
             await viewModel.refresh()
         }
+        #if os(macOS)
         .toolbar {
-            #if os(macOS)
             Button {
                 Task {
                     await viewModel.refresh()
@@ -59,8 +59,9 @@ struct ArticleListView: View {
             .disabled(viewModel.isLoading)
             .keyboardShortcut("r")
             .help("Refresh all channels (⌘ R)")
-            #endif
         }
+        #endif
+        .navigationTitle("Articles")
     }
     
     var noFeedsView: some View {

--- a/AtomReader/View/ContentView.swift
+++ b/AtomReader/View/ContentView.swift
@@ -41,13 +41,16 @@ struct ContentView: View {
                 .navigationTitle("Feeds")
         } detail: {
             NavigationStack(path: $navigationPath) {
-                ArticleListView(
-                    viewModel: ArticleListViewModel(
-                        store: store,
-                        filter: filter ?? .none
+                if filter == .history {
+                    ReadingHistoryView()
+                } else {
+                    ArticleListView(
+                        viewModel: ArticleListViewModel(
+                            store: store,
+                            filter: filter ?? .none
+                        )
                     )
-                )
-                .navigationTitle("Articles")
+                }
             }
             .handleOpenArticleAction(navigationPath: $navigationPath)
         }

--- a/AtomReader/View/ReadingHistoryView.swift
+++ b/AtomReader/View/ReadingHistoryView.swift
@@ -34,6 +34,11 @@ struct ReadingHistoryView: View {
                 readingHistory.mark(articles: articles, read: false)
             }
         }
+        .overlay {
+            if readingHistory.readArticles.isEmpty {
+                emptyReadingHistoryView
+            }
+        }
         .navigationTitle("History")
         .toolbar {
             ToolbarItem(placement: .destructiveAction) {
@@ -62,6 +67,14 @@ struct ReadingHistoryView: View {
         #if os(iOS)
         .listStyle(.plain)
         #endif
+    }
+    
+    var emptyReadingHistoryView: some View {
+        ContentUnavailableView {
+            Text("No reading history")
+        } description: {
+            Text("Read some articles. They'll show up here when you do.")
+        }
     }
 }
 

--- a/AtomReader/View/ReadingHistoryView.swift
+++ b/AtomReader/View/ReadingHistoryView.swift
@@ -1,0 +1,62 @@
+//
+//  ReadingHistoryView.swift
+//  AtomReader
+//
+//  Created by Inal Gotov on 2023-11-21.
+//
+
+import SwiftUI
+
+struct ReadingHistoryView: View {
+    @Environment(ReadingHistoryStore.self) private var readingHistory
+    
+    var sortedEntries: [ReadArticle] {
+        readingHistory.readArticles.sorted(using: KeyPathComparator(\.readAt, order: .reverse))
+    }
+    
+    var body: some View {
+        List {
+            ForEach(sortedEntries) { entry in
+                let action = OpenArticleAction(article: entry.article, shouldSkipHistoryTracking: true)
+                
+                AppActionButton(action) {
+                    Row(entry: entry)
+                }
+            }
+            .onDelete { offsets in
+                let articles = offsets
+                    .map({ sortedEntries[$0] })
+                    .map(\.article)
+                readingHistory.mark(articles: articles, read: false)
+            }
+        }
+        .navigationTitle("History")
+        .listStyle(.plain)
+    }
+}
+
+extension ReadingHistoryView {
+    struct Row: View {
+        let entry: ReadArticle
+        
+        private var dateString: String {
+            entry.readAt
+                .formatted(.relative(presentation: .named))
+        }
+        
+        var body: some View {
+            VStack(alignment: .leading) {
+                Text(entry.article.title)
+                    .font(.title2)
+                
+                Text(dateString)
+                    .foregroundStyle(.secondary)
+                    .font(.caption)
+            }
+        }
+    }
+}
+
+#Preview {
+    ReadingHistoryView()
+}

--- a/AtomReader/View/ReadingHistoryView.swift
+++ b/AtomReader/View/ReadingHistoryView.swift
@@ -10,6 +10,8 @@ import SwiftUI
 struct ReadingHistoryView: View {
     @Environment(ReadingHistoryStore.self) private var readingHistory
     
+    @State private var isClearingHistory: Bool = false
+    
     var sortedEntries: [ReadArticle] {
         readingHistory.readArticles.sorted(using: KeyPathComparator(\.readAt, order: .reverse))
     }
@@ -33,6 +35,30 @@ struct ReadingHistoryView: View {
             }
         }
         .navigationTitle("History")
+        .toolbar {
+            ToolbarItem(placement: .destructiveAction) {
+                Button("Clear") {
+                    isClearingHistory = true
+                }
+            }
+        }
+        .confirmationDialog(
+            "Are you sure you want to clear your reading history?",
+            isPresented: $isClearingHistory
+        ) {
+            Button("Clear", role: .destructive) {
+                readingHistory.clear()
+            }
+            
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            #if os(iOS)
+            Text("Are you sure you want to clear your reading history? This action cannot be undone.")
+            #elseif os(macOS)
+            Text("This action cannot be undone.")
+            #endif
+        }
+
         #if os(iOS)
         .listStyle(.plain)
         #endif

--- a/AtomReader/View/ReadingHistoryView.swift
+++ b/AtomReader/View/ReadingHistoryView.swift
@@ -21,7 +21,9 @@ struct ReadingHistoryView: View {
                 
                 AppActionButton(action) {
                     Row(entry: entry)
+                        .contentShape(Rectangle())
                 }
+                .buttonStyle(.plain)
             }
             .onDelete { offsets in
                 let articles = offsets
@@ -31,7 +33,9 @@ struct ReadingHistoryView: View {
             }
         }
         .navigationTitle("History")
+        #if os(iOS)
         .listStyle(.plain)
+        #endif
     }
 }
 
@@ -53,6 +57,8 @@ extension ReadingHistoryView {
                     .foregroundStyle(.secondary)
                     .font(.caption)
             }
+            .multilineTextAlignment(.leading)
+            .frame(maxWidth: .infinity, alignment: .topLeading)
         }
     }
 }

--- a/AtomReader/ViewModels/ArticleListViewModel.swift
+++ b/AtomReader/ViewModels/ArticleListViewModel.swift
@@ -21,10 +21,10 @@ final class ArticleListViewModel {
     var articles: [Article] {
         let output =
             switch filter {
-            case .none:
-                store.articles
             case .feed(let feedId):
                 store.articles(for: feedId)
+            case .none, .history:
+                store.articles
             }
         return output.sorted(using: KeyPathComparator(\Article.publishedAt, order: .reverse))
     }

--- a/AtomReaderTests/Business/ReadingHistoryStorePersistenceTests.swift
+++ b/AtomReaderTests/Business/ReadingHistoryStorePersistenceTests.swift
@@ -50,6 +50,51 @@ final class ReadingHistoryStorePersistenceTests: XCTestCase {
         XCTAssertEqual(manager.saveArticlesCalls.count, 1)
         XCTAssertEqual(manager.saveArticlesCalls.first?.arguments, Array(manager.readArticles.dropLast()))
     }
+    
+    func test_markArticlesRead_whenMarkingRead_saves() async {
+        let manager = MockReadingHistoryStorePersistenceManager(
+            articles: [mockFeed1Article1]
+                .map({ ReadArticle(article: $0, readAt: Date()) })
+        )
+        let sut = ReadingHistoryStore(persistenceManager: manager)
+        
+        try? await Task.sleep(for: .milliseconds(100))
+        
+        sut.mark(articles: [mockFeed1Article2], read: true)
+        
+        XCTAssertEqual(manager.saveArticlesCalls.count, 1)
+        XCTAssertEqual(manager.saveArticlesCalls.first?.arguments.count, 2)
+    }
+    
+    func test_markArticlesRead_whenMarkingUnread_saves() async {
+        let manager = MockReadingHistoryStorePersistenceManager(
+            articles: [mockFeed1Article1, mockFeed1Article2]
+                .map({ ReadArticle(article: $0, readAt: Date()) })
+        )
+        let sut = ReadingHistoryStore(persistenceManager: manager)
+        
+        try? await Task.sleep(for: .milliseconds(100))
+        
+        sut.mark(articles: [mockFeed1Article2], read: false)
+        
+        XCTAssertEqual(manager.saveArticlesCalls.count, 1)
+        XCTAssertEqual(manager.saveArticlesCalls.first?.arguments, Array(manager.readArticles.dropLast()))
+    }
+    
+    func test_clear_saves() async {
+        let manager = MockReadingHistoryStorePersistenceManager(
+            articles: [mockFeed1Article1, mockFeed1Article2]
+                .map({ ReadArticle(article: $0, readAt: Date()) })
+        )
+        let sut = ReadingHistoryStore(persistenceManager: manager)
+        
+        try? await Task.sleep(for: .milliseconds(100))
+        
+        sut.clear()
+        
+        XCTAssertEqual(manager.saveArticlesCalls.count, 1)
+        XCTAssertTrue(manager.saveArticlesCalls.first!.arguments.isEmpty)
+    }
 }
 
 class MockReadingHistoryStorePersistenceManager: ReadingHistoryStorePersistenceManager {

--- a/AtomReaderTests/Business/ReadingHistoryStoreTests.swift
+++ b/AtomReaderTests/Business/ReadingHistoryStoreTests.swift
@@ -187,3 +187,11 @@ extension ReadingHistoryStoreTests {
         XCTAssertFalse(isRead)
     }
 }
+
+extension ReadingHistoryStoreTests {
+    func test_clear_removesAllReadArticles() {
+        sut.clear()
+        
+        XCTAssertTrue(sut.readArticles.isEmpty)
+    }
+}

--- a/AtomReaderTests/Business/ReadingHistoryStoreTests.swift
+++ b/AtomReaderTests/Business/ReadingHistoryStoreTests.swift
@@ -83,6 +83,98 @@ extension ReadingHistoryStoreTests {
 }
 
 extension ReadingHistoryStoreTests {
+    func test_markArticlesRead_whenNewArticlesRead_setRecentDateForNewReadArticle() throws {
+        let sut = ReadingHistoryStore(readArticles: [mockReadFeed1Article1])
+        let newArticle1 = mockFeed1Article2
+        let newArticle2 = mockFeed2Article1
+        
+        let dateBeforeAdd = Date()
+        sut.mark(articles: [newArticle1, newArticle2], read: true)
+        
+        let article1 = try XCTUnwrap(sut.readArticles.first(where: { $0.article == newArticle1 }))
+        XCTAssertEqual(
+            article1.readAt.timeIntervalSinceReferenceDate,
+            dateBeforeAdd.timeIntervalSinceReferenceDate,
+            accuracy: 1
+        )
+        
+        let article2 = try XCTUnwrap(sut.readArticles.first(where: { $0.article == newArticle2 }))
+        XCTAssertEqual(
+            article2.readAt.timeIntervalSinceReferenceDate,
+            dateBeforeAdd.timeIntervalSinceReferenceDate,
+            accuracy: 1
+        )
+    }
+    
+    func test_markArticlesRead_whenNewArticleRead_addsToReadArticles() {
+        let sut = ReadingHistoryStore(readArticles: [mockReadFeed1Article1])
+        let newArticle1 = mockFeed1Article2
+        let newArticle2 = mockFeed2Article1
+        
+        sut.mark(articles: [newArticle1, newArticle2], read: true)
+        
+        let readArticles = Set(sut.readArticles.map(\.article))
+        let expectedArticles = Set([newArticle1, newArticle2, mockFeed1Article1])
+        
+        XCTAssertEqual(readArticles, expectedArticles)
+    }
+    
+    func test_markArticlesRead_whenAlreadyReadArticleRead_resetReadAt() throws {
+        let sut = ReadingHistoryStore(readArticles: [mockReadFeed1Article1, mockReadFeed2Article1])
+        let newArticle = mockFeed1Article2
+        let alreadyReadArticle = mockFeed2Article1
+        
+        let dateBeforeAdd = Date()
+        sut.mark(articles: [newArticle, alreadyReadArticle], read: true)
+        
+        XCTAssertTrue(sut.readArticles.contains(where: { $0.article == newArticle }))
+        
+        let readArticle = try XCTUnwrap(sut.readArticles.first(where: { $0.article == alreadyReadArticle }))
+        XCTAssertEqual(
+            readArticle.readAt.timeIntervalSinceReferenceDate,
+            dateBeforeAdd.timeIntervalSinceReferenceDate,
+            accuracy: 1
+        )
+    }
+    
+    func test_markArticlesRead_whenNewArticleUnread_makesNoChanges() {
+        let sut = ReadingHistoryStore(readArticles: [mockReadFeed1Article1])
+        let newArticle1 = mockFeed1Article2
+        let newArticle2 = mockFeed2Article1
+        
+        sut.mark(articles: [newArticle1, newArticle2], read: false)
+        
+        let readArticles = Set(sut.readArticles.map(\.article))
+        let expectedArticles = Set([mockFeed1Article1])
+        
+        XCTAssertEqual(readArticles, expectedArticles)
+    }
+    
+    func test_markArticlesRead_whenAlreadyReadArticleUnread_removesFromReadArticles() {
+        let sut = ReadingHistoryStore(readArticles: [mockReadFeed1Article1, mockReadFeed2Article1])
+        let newArticle = mockFeed1Article2
+        let alreadyReadArticle = mockFeed2Article1
+        
+        sut.mark(articles: [newArticle, alreadyReadArticle], read: false)
+        
+        let readArticles = Set(sut.readArticles.map(\.article))
+        let expectedArticles = Set([mockFeed1Article1])
+        
+        XCTAssertEqual(readArticles, expectedArticles)
+    }
+    
+    func test_markArticlesRead_whenNoArticlesProvided_makesNoChange() {
+        let articlesBeforeChange = sut.readArticles
+        
+        sut.mark(articles: [], read: true)
+        XCTAssertEqual(sut.readArticles, articlesBeforeChange)
+        
+        sut.mark(articles: [], read: false)
+        XCTAssertEqual(sut.readArticles, articlesBeforeChange)
+    }
+}
+
+extension ReadingHistoryStoreTests {
     func test_isArticleRead_whenReadArticleProvided() {
         let isRead = sut.isArticleRead(mockFeed1Article1)
         


### PR DESCRIPTION
Added a reading history view in the article filter list. This view will show a reverse chronological list of all the read articles. You can open the articles from this list without affecting your history, or remove them from here.
